### PR TITLE
[nemo-qml-plugin-thumbnailer] Allow use in auto tests

### DIFF
--- a/src/nemothumbnailitem.cpp
+++ b/src/nemothumbnailitem.cpp
@@ -280,6 +280,7 @@ NemoThumbnailLoader::NemoThumbnailLoader(QObject *parent)
 
 NemoThumbnailLoader::~NemoThumbnailLoader()
 {
+    instance = 0;
 }
 
 void NemoThumbnailLoader::updateRequest(NemoThumbnailItem *item, bool identityChanged)

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -60,9 +60,11 @@ public:
         Q_ASSERT(uri == QLatin1String("org.nemomobile.thumbnailer"));
         engine->addImageProvider(QLatin1String("nemoThumbnail"), new NemoThumbnailProvider);
 
-        NemoThumbnailLoader *loader = new NemoThumbnailLoader;
-        loader->start(QThread::IdlePriority);
-        qAddPostRoutine(NemoThumbnailLoader::shutdown);
+        if (!NemoThumbnailLoader::instance) {
+            NemoThumbnailLoader *loader = new NemoThumbnailLoader;
+            loader->start(QThread::IdlePriority);
+            qAddPostRoutine(NemoThumbnailLoader::shutdown);
+        }
     }
 
     void registerTypes(const char *uri)


### PR DESCRIPTION
Auto tests can instantiate the QML engine repeatedly without halting
the QApplication.
