### PR TITLE
[nemo-qml-plugin-thumbnailer] Fix borders on thumbnails.

### DIFF
--- a/src/nemothumbnailprovider.cpp
+++ b/src/nemothumbnailprovider.cpp
@@ -252,7 +252,7 @@ QImage NemoThumbnailProvider::generateThumbnail(const QString &id, const QByteAr
             scaledSize.scale(requestedSize, Qt::KeepAspectRatioByExpanding);
 
             // set the adjusted clipping rectangle in the center of the scaled image
-            QPoint center(scaledSize.width() / 2, scaledSize.height() / 2);
+            QPoint center((scaledSize.width() - 1) / 2, (scaledSize.height() - 1) / 2);
             QRect cr(0,0,requestedSize.width(), requestedSize.height());
             cr.moveCenter(center);
             ir.setScaledClipRect(cr);


### PR DESCRIPTION
Centering a 180x180 rectangle around a point at 90x90 gives a rectangle
with the top left at (1,1) not (0,0) so the crop rectangle ends up
slightly outside the bounds of the image.  Biasing the width and height by 1
when dividing to get the center gives a 1x1 negative offset necessary to
get the correct center for even sizes without overcompensating for odd
widths.
